### PR TITLE
Each vehicle should hold relative information on other vehicles

### DIFF
--- a/src/algorithms/continuous/algorithm1.py
+++ b/src/algorithms/continuous/algorithm1.py
@@ -1,37 +1,31 @@
-from ...models.continuous.ContinuousVehicle import ContinuousVehicle, VehicleType
+from typing import List
+from ...models.continuous.ContinuousVehicle import ContinuousVehicle, Control, LateralDirection, VehicleType
 from ...utils.Vector2 import Vector2
 
 class ContinuousCivilianVehicle(ContinuousVehicle):
 	_width = 2
 	_length = 3
+	collision_test_points_local_frame: List[Vector2] = []
 
-	def __init__(self, position: Vector2, velocity: Vector2, heading: float = 0):
-		super().__init__(VehicleType.civilian, position, velocity, heading)
-
-	def update_velocity(self):
-		self._velocity = Vector2(0.5, 0)
+	def __init__(self):
+		super().__init__(VehicleType.civilian)
 
 	def contains(self, position: Vector2) -> bool:
-		relative_position = position - self.position
-		relative_position_vehicle_frame = relative_position.rotated_clockwise(self._heading)
-		x_rel, y_rel = relative_position_vehicle_frame.x, relative_position_vehicle_frame.y
-		return -self._width / 2 < x_rel < self._width / 2 and -self._length / 2 < y_rel < self._length / 2
+		return -self._width / 2 < position.x < self._width / 2 and -self._length / 2 < position.y < self._length / 2
+
+	def compute_control(self) -> Control:
+		return Control(2, LateralDirection.left, 50)
 
 class ContinuousEmergencyVehicle(ContinuousVehicle):
 	_width = 2
 	_length = 3
+	collision_test_points_local_frame: List[Vector2] = []
 
-	def __init__(self, position: Vector2, velocity: Vector2, heading: float = 0):
-		super().__init__(VehicleType.emergency, position, velocity, heading)
-
-	def update_velocity(self):
-		self._velocity = Vector2(1, 0)
+	def __init__(self):
+		super().__init__(VehicleType.emergency)
 
 	def contains(self, position: Vector2) -> bool:
-		relative_position = position - self.position
-		relative_position_vehicle_frame = relative_position.rotated_clockwise(self._heading)
-		x_rel, y_rel = relative_position_vehicle_frame.x, relative_position_vehicle_frame.y
-		return -self._width / 2 < x_rel < self._width / 2 and -self._length / 2 < y_rel < self._length / 2
+		return -self._width / 2 < position.x < self._width / 2 and -self._length / 2 < position.y < self._length / 2
 
-def position_is_obstacle(position: Vector2) -> bool:
-	return -3 < position.y < -2 or 6 < position.y < 7
+	def compute_control(self) -> Control:
+		return Control(1, LateralDirection.right, 50)

--- a/src/algorithms/discrete/breadth_first.py
+++ b/src/algorithms/discrete/breadth_first.py
@@ -1,7 +1,6 @@
 from typing import List
-from dataclasses import dataclass
 from ...models.discrete.DiscreteVehicle import DiscreteVehicle
-from ...models.discrete.utils import DiscretePosition, DiscreteVehicleType, Grid, DiscreteSimulationCellType
+from ...models.discrete.utils import DiscretePosition, DiscreteVehicleType, Grid
 from .utils import possible_moves, is_road, is_goal, get_next_position
 
 History = List[DiscretePosition]

--- a/src/algorithms/discrete/depth_first.py
+++ b/src/algorithms/discrete/depth_first.py
@@ -1,6 +1,6 @@
 from typing import List
 from ...models.discrete.DiscreteVehicle import DiscreteVehicle
-from ...models.discrete.utils import DiscretePosition, DiscreteVehicleType, Grid, DiscreteSimulationCellType
+from ...models.discrete.utils import DiscretePosition, DiscreteVehicleType, Grid
 from .utils import possible_moves, is_road, is_goal, get_next_position
 
 def solve_maze(
@@ -23,7 +23,7 @@ def solve_maze(
 				break
 		if has_been_there: continue
 
-		# if the proposal is road, try find a path from there
+		# if the proposal is road, try to find a path from there
 		if is_road(proposal, grid):
 			result = solve_maze(grid, proposal, [*history, current_position])
 			if result is not None:

--- a/src/continuous_main.py
+++ b/src/continuous_main.py
@@ -1,9 +1,11 @@
 import copy
 from typing import List
 from dataclasses import dataclass
+import numpy as np
 
 # imports for simulation
-from .models.continuous.ContinuousSimulator import ContinuousSimulator
+from src.models.continuous.ContinuousVehicle import ContinuousVehicle, VehicleType
+from .models.continuous.ContinuousSimulator import ContinuousSimulator, VehicleData
 from .algorithms.continuous.algorithm1 import ContinuousCivilianVehicle, ContinuousEmergencyVehicle
 from .scenarios.continuous.scenario1 import scenario
 
@@ -11,16 +13,13 @@ from .scenarios.continuous.scenario1 import scenario
 from .utils.Vector2 import Vector2
 from .visualize.visualize import visualize_result, VisualisationCellType, Extent
 
-def get_visualization_cell_type(
-	position: Vector2,
-	civilians: List[ContinuousCivilianVehicle],
-	emergencies: List[ContinuousEmergencyVehicle]
-) -> VisualisationCellType:
+
+def get_visualization_cell_type(position: Vector2, vehicles: List[VehicleData]):
 	if scenario.position_is_in_obstacle(position): return VisualisationCellType.obstacle
-	for civilian in civilians:
-		if civilian.contains(position): return VisualisationCellType.civilian
-	for emergency in emergencies:
-		if emergency.contains(position): return VisualisationCellType.emergency
+	for v in vehicles:
+		if v.object.contains(v.position_world_to_relative(position)):
+			if v.object.vehicle_type == VehicleType.emergency: return VisualisationCellType.emergency
+			if v.object.vehicle_type == VehicleType.civilian: return VisualisationCellType.civilian
 	return VisualisationCellType.road
 
 @dataclass
@@ -30,32 +29,29 @@ class SimulationSnapshot:
 
 def continuous_main():
 	# given scenario, set up the simulator and the vehicles
-	civilians = [ContinuousCivilianVehicle(c.position, c.velocity) for c in scenario.civilians]
-	emergencies = [ContinuousEmergencyVehicle(e.position, e.velocity) for e in scenario.emergencies]
-	simulator = ContinuousSimulator(scenario.position_is_in_obstacle, [*civilians, *emergencies])
+	simulator = ContinuousSimulator(
+		scenario.position_is_in_obstacle,
+		[VehicleData(ContinuousCivilianVehicle(), c.position, c.velocity, 0) for c in scenario.civilians]
+		+ [VehicleData(ContinuousEmergencyVehicle(), e.position, e.velocity, 0) for e in scenario.emergencies]
+	)
 
 	# simulate
-	dt, total_time = 0.5, 5
+	dt, total_time = 2, 50 * np.pi / 2
 	n_iter = int(total_time / dt)
 	t = 0
-	data: List[SimulationSnapshot] = []
+	data: List[List[VehicleData]] = []
 	for i in range(n_iter):
-		for v in simulator.vehicles:
-			v._heading += 0.1 # included as an example
-			v.update_velocity()
-
 		simulator.roll_forward(dt)
-		data.append(SimulationSnapshot(copy.deepcopy(civilians), copy.deepcopy(emergencies)))
+		data.append(copy.deepcopy(simulator.vehicles))
 		t += dt
 		print(f'\rt={t}', end='')
 
 	# visualize
-	for i in range(n_iter):
-		snapshot = data[i]
+	for snapshot in data:
 		visualize_result(
-			lambda x: get_visualization_cell_type(x, snapshot.civilians, snapshot.emergencies),
-			0.1,
-			Extent(-5, 5, -5, 10)
+			lambda x: get_visualization_cell_type(x, snapshot),
+			0.3,
+			Extent(-50, 50, -10, 50)
 		)
 
 if __name__ == '__main__':

--- a/src/discrete_main.py
+++ b/src/discrete_main.py
@@ -31,7 +31,7 @@ def get_visualization_cell_type(position: Vector2, grid: Grid) -> VisualisationC
 def discrete_main():
 	# given scenario, set up the simulator and the vehicles
 	civilians = [DiscreteCivilianVehicle(pos) for pos in scenario.civilian_positions]
-	emergencies = [DiscreteEmergencyVehicle(pos) for pos in scenario.emergencie_positions]
+	emergencies = [DiscreteEmergencyVehicle(pos) for pos in scenario.emergency_positions]
 	simulator = DiscreteSimulator(scenario.grid, [*civilians, *emergencies])
 
 	# simulate

--- a/src/models/continuous/ContinuousSimulator.py
+++ b/src/models/continuous/ContinuousSimulator.py
@@ -1,37 +1,101 @@
 from typing import List, Callable
-from .ContinuousVehicle import ContinuousVehicle
+from dataclasses import dataclass
+import numpy as np
+from .ContinuousVehicle import ContinuousVehicle, LateralDirection, ObservedVehicle
 from ...utils.Vector2 import Vector2
 
+@dataclass
+class VehicleData:
+	object: ContinuousVehicle
+	position: Vector2
+	velocity: Vector2
+	_heading: float # between zero and two pi
+
+	@property
+	def heading(self): return self._heading
+
+	@heading.setter
+	def heading(self, value: float):
+		# Make sure the heading is between zero and two pi
+		self._heading = value
+		while self._heading < 0: self._heading += 2 * np.pi
+		while self._heading > 2 * np.pi: self._heading -= 2 * np.pi
+
+	def position_relative_to_world(self, relative_position: Vector2):
+		return relative_position.rotated_clockwise(-self.heading) + self.position
+
+	def position_world_to_relative(self, world_position: Vector2):
+		return (world_position - self.position).rotated_clockwise(self.heading)
+
+	def velocity_relative_to_world(self, relative_velocity: Vector2):
+		return relative_velocity.rotated_clockwise(-self.heading) + self.velocity
+
+	def velocity_world_to_relative(self, world_velocity: Vector2):
+		return (world_velocity - self.velocity).rotated_clockwise(self.heading)
+
 class ContinuousSimulator:
-	vehicles: List[ContinuousVehicle]
+	vehicles: List[VehicleData]
 	position_is_obstacle: Callable[[Vector2], bool]
 
-	def __init__(self, position_is_obstacle: Callable[[Vector2], bool], vehicles: List[ContinuousVehicle] = None):
+	def __init__(self, position_is_obstacle: Callable[[Vector2], bool], vehicles: List[VehicleData] = None):
 		self.position_is_obstacle = position_is_obstacle
 		self.vehicles = []
 		if vehicles is not None:
 			for v in vehicles:
 				self.add_vehicle(v)
 
-	def add_vehicle(self, vehicle: ContinuousVehicle):
-		for v in self.vehicles:
-			assert v is not vehicle
-			v.add_vehicle(vehicle)
-			vehicle.add_vehicle(v)
-			v._position_is_obstacle = self.position_is_obstacle
+	def add_vehicle(self, vehicle: VehicleData):
+		assert vehicle not in self.vehicles
 		self.vehicles.append(vehicle)
 
-	def remove_vehicle(self, vehicle: ContinuousVehicle):
-		delete_index: None | int = None
-		for index, v in enumerate(self.vehicles):
-			if v is vehicle:
-				delete_index = index
-		assert delete_index is not None
-		for v in self.vehicles:
-			v.remove_vehicle(vehicle)
-
+	def remove_vehicle(self, vehicle: VehicleData):
+		assert vehicle in self.vehicles
+		delete_index = self.vehicles.index(vehicle)
 		del self.vehicles[delete_index]
 
+	def update_observed_data(self):
+		"""Updates information held by each vehicle"""
+		for v1 in self.vehicles:
+			# update observed vehicles
+			v1.object.observed_vehicles = []
+			for v2 in self.vehicles:
+				if v1 is v2: continue
+				# TODO limit the communication radius
+				relative_position = v1.position_world_to_relative(v2.position)
+				relative_velocity = v1.velocity_world_to_relative(v2.velocity)
+				relative_heading = v2.heading - v1.heading
+				# make sure relative heading is between -pi and pi
+				while relative_heading < -np.pi: relative_heading += 2 * np.pi
+				while relative_heading > np.pi: relative_heading -= 2 * np.pi
+
+				def v2_contains(position_v1_frame: Vector2) -> bool:
+					world_position = v1.position_relative_to_world(position_v1_frame)
+					position_v2_frame = v2.position_world_to_relative(world_position)
+					return v2.object.contains(position_v2_frame)
+
+				v1.object.observed_vehicles.append(ObservedVehicle(
+					v2.object.vehicle_type,
+					relative_position,
+					relative_velocity,
+					relative_heading,
+					v2_contains
+				))
+
+			# update obstacle info
+			v1.object.position_is_obstacle = \
+				lambda rel_pos: self.position_is_obstacle(v1.position_relative_to_world(rel_pos))
+
 	def roll_forward(self, dt: float):
+		self.update_observed_data()
+
+		# compute velocity and position based on the new observed data
 		for vehicle in self.vehicles:
-			vehicle._roll_forward(dt)
+			control = vehicle.object.compute_control()
+			delta_distance = control.speed * dt
+			delta_heading = delta_distance / control.turn_radius * (1 if control.turn_direction == LateralDirection.right else -1)
+			average_heading = vehicle.heading + delta_heading / 2 # heading at halfway point
+
+			# update velocity, position and heading
+			vehicle.velocity = Vector2(np.sin(average_heading), np.cos(average_heading)) * control.speed
+			vehicle.position += vehicle.velocity * dt
+			vehicle.heading += delta_heading

--- a/src/models/continuous/ContinuousSimulator.py
+++ b/src/models/continuous/ContinuousSimulator.py
@@ -68,17 +68,12 @@ class ContinuousSimulator:
 				while relative_heading < -np.pi: relative_heading += 2 * np.pi
 				while relative_heading > np.pi: relative_heading -= 2 * np.pi
 
-				def v2_contains(position_v1_frame: Vector2) -> bool:
-					world_position = v1.position_relative_to_world(position_v1_frame)
-					position_v2_frame = v2.position_world_to_relative(world_position)
-					return v2.object.contains(position_v2_frame)
-
 				v1.object.observed_vehicles.append(ObservedVehicle(
 					v2.object.vehicle_type,
 					relative_position,
 					relative_velocity,
 					relative_heading,
-					v2_contains
+					v2.object.contains
 				))
 
 			# update obstacle info

--- a/src/models/continuous/ContinuousVehicle.py
+++ b/src/models/continuous/ContinuousVehicle.py
@@ -25,7 +25,7 @@ class ObservedVehicle:
 	relative_position: Vector2
 	relative_velocity: Vector2
 	relative_heading: float # between -pi and pi
-	contains: Callable[[Vector2], bool] # whether the observed vehicle contains a point in this vehicle's frame
+	contains: Callable[[Vector2], bool] # copy of the contains function of the observed vehicle
 
 class ContinuousVehicle(ABC):
 	_vehicle_type: VehicleType
@@ -67,8 +67,10 @@ class ContinuousVehicle(ABC):
 			if self.position_is_obstacle(test_point): return True
 
 			# check for other vehicles
-			for observed_vehicle in self.observed_vehicles:
-				if observed_vehicle.contains(test_point): return True
+			for v in self.observed_vehicles:
+				rel_pos_this_frame = test_point - v.relative_position
+				rel_pos_other_frame = rel_pos_this_frame.rotated_clockwise(v.relative_heading)
+				if v.contains(rel_pos_other_frame): return True
 		return False
 
 	@abstractmethod

--- a/src/models/continuous/ContinuousVehicle.py
+++ b/src/models/continuous/ContinuousVehicle.py
@@ -1,73 +1,86 @@
 from __future__ import annotations
 from typing import List, Callable
 from enum import Enum
+from dataclasses import dataclass
 from abc import ABC, abstractmethod
-import numpy as np
 from ...utils.Vector2 import Vector2
 
 class VehicleType(Enum):
 	civilian = 0
 	emergency = 1
 
+class LateralDirection(Enum):
+	left = 0
+	right = 1
+
+@dataclass
+class Control:
+	speed: float
+	turn_direction: LateralDirection
+	turn_radius: float
+
+@dataclass
+class ObservedVehicle:
+	vehicle_type: VehicleType
+	relative_position: Vector2
+	relative_velocity: Vector2
+	relative_heading: float # between -pi and pi
+	contains: Callable[[Vector2], bool] # whether the observed vehicle contains a point in this vehicle's frame
+
 class ContinuousVehicle(ABC):
 	_vehicle_type: VehicleType
-	_position: Vector2
-	_velocity: Vector2
-	_other_vehicles: List[ContinuousVehicle]
-	_position_is_obstacle: Callable[[Vector2], bool]
-	_heading: float # between 0 and 2pi with 0 being positive y direction, pi / 2 positive x direction
+	observed_vehicles: List[ObservedVehicle] = []
+	position_is_obstacle: Callable[[Vector2], bool] # returns whether the given relative position is in an obstacle
 
-	def __init__(self, vehicle_type: VehicleType, position: Vector2, velocity: Vector2, heading: float = 0):
+	def __init__(self, vehicle_type: VehicleType):
 		self._vehicle_type = vehicle_type
-		self._position = position
-		self._velocity = velocity
-		self._other_vehicles = []
-		self._heading = heading
 
 	@property
 	def vehicle_type(self): return self._vehicle_type
 
 	@property
-	def position(self): return self._position
-
-	@property
-	def velocity(self): return self._velocity
-
-	@property
-	def heading(self): return self._heading
-
-	@heading.setter
-	def heading(self, value: float): self._heading = value % (2 * np.pi)
-
-	def _roll_forward(self, dt: float):
-		self._position += self._velocity * dt
-
-	def add_vehicle(self, vehicle: ContinuousVehicle):
-		assert self is not vehicle
-		for v in self._other_vehicles:
-			assert v is not vehicle
-		self._other_vehicles.append(vehicle)
-
-	def remove_vehicle(self, vehicle: ContinuousVehicle):
-		remove_index: None | int = None
-		for index, v in enumerate(self._other_vehicles):
-			if v is vehicle:
-				remove_index = index
-				break
-		assert remove_index is not None
-		del self._other_vehicles[remove_index]
-
 	@abstractmethod
-	def update_velocity(self):
+	def collision_test_points_local_frame(self) -> List[Vector2]:
 		"""
-		This function should update the velocity property based on the information the vehicle holds.
+		This property contains all the points (in this vehicle's frame) that need to be tested for collision.
+		e.g. 100 points around the edges of the vehicle.
 		"""
 		raise NotImplementedError
+
+	@collision_test_points_local_frame.setter
+	@abstractmethod
+	def collision_test_points_local_frame(self, value: List[Vector2]):
+		raise NotImplementedError
+
+	def position_will_collide(self, relative_position: Vector2, relative_heading: float) -> bool:
+		"""
+		Returns whether the given position and heading (in the vehicle frame)
+		would collide with another vehicle or an obstacle.
+
+		:param relative_position:  the proposed position in the vehicle frame
+		:param relative_heading: relative heading at the proposed position
+		"""
+		for p in self.collision_test_points_local_frame:
+			test_point = relative_position + p.rotated_clockwise(-relative_heading)
+
+			# check for obstacle
+			if self.position_is_obstacle(test_point): return True
+
+			# check for other vehicles
+			for observed_vehicle in self.observed_vehicles:
+				if observed_vehicle.contains(test_point): return True
+		return False
 
 	@abstractmethod
 	def contains(self, position: Vector2) -> bool:
 		"""
-		This function should return whether the given position lies within this vehicle.
+		This function should return whether the given position (in this vehicle's frame) lies within this vehicle.
 		"""
+		raise NotImplementedError
+
+	# The following two methods will be used instead of compute_velocity when we incorporate the car dynamics.
+	@abstractmethod
+	def compute_control(self) -> Control:
+		"""This function should compute the speed at next time step"""
 		raise NotImplementedError
 

--- a/src/models/discrete/utils.py
+++ b/src/models/discrete/utils.py
@@ -1,4 +1,4 @@
-from typing import Tuple, List
+from typing import List
 from enum import Enum
 from dataclasses import dataclass
 

--- a/src/scenarios/continuous/scenario1.py
+++ b/src/scenarios/continuous/scenario1.py
@@ -7,12 +7,10 @@ civilians: List[VehicleInitializationInfo] = [
 ]
 
 emergencies: List[VehicleInitializationInfo] = [
-	VehicleInitializationInfo(Vector2(0, 4), Vector2(0, 0))
+	VehicleInitializationInfo(Vector2(2, 0), Vector2(0, 0))
 ]
 
 def position_is_in_obstacle(position: Vector2):
-	if 7 < position.y < 8: return True
-	if -4 < position.y < -3: return True
 	return False
 
 scenario = Scenario(civilians, emergencies, position_is_in_obstacle)

--- a/src/scenarios/discrete/Scenario.py
+++ b/src/scenarios/discrete/Scenario.py
@@ -1,11 +1,10 @@
 import copy
-from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List
 from ...models.discrete.DiscreteSimulator import DiscreteSimulationCellType, DiscretePosition
 
 class Scenario:
 	civilian_positions: List[DiscretePosition]
-	emergencie_positions: List[DiscretePosition]
+	emergency_positions: List[DiscretePosition]
 	grid: List[List[DiscreteSimulationCellType]]
 
 	def __init__(
@@ -32,5 +31,5 @@ class Scenario:
 		grid_copy.append([DiscreteSimulationCellType.obstacle for _ in range(original_width + 2)])
 
 		self.civilian_positions = civilians_copy
-		self.emergencie_positions = emergencies_copy
+		self.emergency_positions = emergencies_copy
 		self.grid = grid_copy


### PR DESCRIPTION
Issue: #14

## Changes
- The simulator manages the world position, velocity and heading of the vehicles through `VehicleData`. 
- Each vehicle now receives
  - relative position
  - relative velocity
  - vehicle type
  - `contains` function 
of the surrounding vehicles
- The above information is computed by the simulator in `update_observed_data()` function. This effectively simulates the sensing of the surrounding vehicles and obstacles.
- Vehicles now need to implement three things: `collision_test_points_local_frame`, `contains` and `compute_control`.
  - `collision_test_points_local_frame` should have the points around the vehicle to be tested for collision detection e.g. 100 points around the edges of the vehicle. We can check if each of these points lies outside any obstacle. (more sophisticated methods can be used in the future, but this should be good enough for now?)
  - `contains` function returns whether some position in the relative frame is contained by the vehicle itself
  - `compute_control` returns a `Control` which should have the desired speed, turn direction and turn radius. As we transitioned to using relative position / velocity for control, it did not make sense any more to use `compute_velocity` directly from the vehicle because it does not hold any information about the world. So I thought it might be best to jump onto the car dynamics with non-holonomocity.